### PR TITLE
Template no actual tests

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -15,8 +15,6 @@ RUN apt-get update
 RUN apt-get install -y libgl1 libglu1-mesa && \
     apt-get clean
 
-RUN mkdir -p /opt/scripts
-
 # updating scipp and run tests
 CMD conda install --yes \
     -c scipp/label/dev scipp && \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,23 @@
+#The oficial image from Anaconda
+FROM conda/miniconda3
+# The default version of conda is broken
+RUN conda update -n base -c defaults conda
+# Install mantid
+RUN conda install --yes \
+    -c conda-forge \
+    -c mantid/label/nightly \
+    -c mantid \
+    mantid-framework=4 \
+    pytest
+
+# needed for mantid for some reason
+RUN apt-get update
+RUN apt-get install -y libgl1 libglu1-mesa && \
+    apt-get clean
+
+RUN mkdir -p /opt/scripts
+
+# updating scipp and run tests
+CMD conda install --yes \
+    -c scipp/label/dev scipp && \
+    pytest /opt/tests

--- a/build_docker.py
+++ b/build_docker.py
@@ -1,0 +1,16 @@
+import argparse
+import subprocess as sp
+import os
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Buids docker immage for "
+                                                 "testing scipp against "
+                                                 "Mantid")
+    parser.add_argument("--image_name", type=str, default="scipp_vs_mantid",
+                        help="the name of the image to start")
+
+    args = parser.parse_args()
+    docker_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                               "Docker")
+    command = "docker build -t {} {}".format(args.image_name, docker_path)
+    sp.run(command, check=True, shell=True)

--- a/run_comparison_tests.py
+++ b/run_comparison_tests.py
@@ -1,0 +1,17 @@
+import argparse
+import subprocess as sp
+import os
+import sys
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Runs docker for testing "
+                                                 "scipp against Mantid")
+    parser.add_argument("--image_name", type=str, default="scipp_vs_mantid",
+                        help="the name of the image to start")
+
+    test_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                               "tests")
+    args = parser.parse_args()
+    command = "docker run -v {}:/opt/tests {}".format(
+        test_folder, args.image_name)
+    sys.exit(sp.run(command, shell=True).returncode)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,12 @@
+import scipp as sc
+import mantid.simpleapi as mantid
+
+
+def test_dummy_pass():
+    print("hello world!")
+    assert True
+
+
+def test_dummy_fail():
+    print("hello world!")
+    assert False


### PR DESCRIPTION
Docker file is based on image provided by Anaconda  and contains Mantid and pytests. Python scripts are added to simplify deployment and launching tests. Tests could be added in /tests directory treated by pytest.

The pipeline considered to be following:
1. Given virtual machine - jenkins slave with docker daemon installed.
2. For deploying: clone repo and run buid_docker.py
3. To run tests launch run comparison tests.